### PR TITLE
Add configuration file and destination-aware CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,31 @@ pruebas de latencia y observar el estado de la conexión.
 python app.py <host> [puerto]
 ```
 
+### Usar archivo de configuración
+
+Define destinos en `config.yaml` (JSON válido):
+
+```yaml
+{
+  "destinations": {
+    "local": {"ip": "127.0.0.1", "port": 5060, "protocol": "UDP", "interval": 5},
+    "backup": {"ip": "192.0.2.10", "port": 5080, "protocol": "TCP", "interval": 10}
+  }
+}
+```
+
+Selecciona un destino y envía OPTIONS periódicos:
+
+```bash
+python app.py -c config.yaml -n local --count 0
+```
+
+Para usar un puerto alternativo:
+
+```bash
+python app.py -c config.yaml -n local --port 5070
+```
+
 ### Interfaz interactiva
 
 ```bash

--- a/config.py
+++ b/config.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict
+
+
+@dataclass
+class Destination:
+    ip: str
+    port: int = 5060
+    protocol: str = "UDP"
+    interval: int = 60
+
+
+def load_config(path: str | Path) -> Dict[str, Destination]:
+    """Load destination configuration from *path*.
+
+    The file is expected to contain a JSON or YAML mapping with a top-level
+    ``destinations`` object. YAML files using only simple mappings are also
+    supported as they are valid JSON.
+    """
+    with open(path, "r", encoding="utf-8") as fh:
+        data = json.load(fh)
+    dests = {}
+    for name, cfg in data.get("destinations", {}).items():
+        dests[name] = Destination(
+            ip=cfg["ip"],
+            port=int(cfg.get("port", 5060)),
+            protocol=str(cfg.get("protocol", "UDP")).upper(),
+            interval=int(cfg.get("interval", 60)),
+        )
+    return dests

--- a/config.yaml
+++ b/config.yaml
@@ -1,0 +1,16 @@
+{
+  "destinations": {
+    "local": {
+      "ip": "127.0.0.1",
+      "port": 5060,
+      "protocol": "UDP",
+      "interval": 5
+    },
+    "backup": {
+      "ip": "192.0.2.10",
+      "port": 5080,
+      "protocol": "TCP",
+      "interval": 10
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- load destinations from a `config.yaml` file with IP, port, protocol and interval
- extend CLI to choose a destination, override ports and send periodic OPTIONS
- document configuration usage and provide sample config

## Testing
- `python -m py_compile app.py config.py sip_manager.py socket_handler.py ui/main.py`
- `python app.py -c config.yaml -n local --count 1` *(fails: Timeout esperando respuesta UDP de 127.0.0.1:5060)*

------
https://chatgpt.com/codex/tasks/task_e_68b95159f14c832987ee611a108f4ce1