### PR TITLE
docs: add ubuntu installation and usage examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,60 @@ Monitor sencillo para verificar servidores SIP mediante mensajes OPTIONS e
 INVITE. Incluye una interfaz de terminal basada en `curses` para realizar
 pruebas de latencia y observar el estado de la conexión.
 
-## Uso
+## Instalación en Ubuntu
+
+```bash
+sudo apt update && sudo apt install -y python3 python3-pip git
+git clone https://example.com/Dimitri_4000.git
+cd Dimitri_4000
+# opcional: python3 -m venv venv && source venv/bin/activate
+```
+
+No se requieren dependencias adicionales, el proyecto usa únicamente la
+biblioteca estándar de Python.
+
+### Permisos para puertos <1024
+
+El puerto SIP por defecto es el **5060**, que está por debajo del límite de
+puertos privilegiados. Para poder enlazarlo se puede:
+
+* Ejecutar el script con `sudo`.
+* Otorgar la capacidad `CAP_NET_BIND_SERVICE` al intérprete de Python:
+
+  ```bash
+  sudo setcap 'cap_net_bind_service=+ep' $(which python3)
+  ```
+
+* Usar la opción `--port` para elegir un puerto mayor a 1024.
+
+## Configuración y parámetros
+
+### Archivo de configuración
+
+Define destinos en `config.yaml` (JSON válido). Cada destino acepta los
+siguientes campos:
+
+- `ip`: dirección del servidor remoto.
+- `port`: puerto SIP (por defecto 5060).
+- `protocol`: `UDP` o `TCP`.
+- `interval`: segundos entre solicitudes repetidas.
+- `timeout`: tiempo de espera por respuesta.
+- `retries`: reintentos ante errores o timeouts.
+
+### Parámetros de ejecución
+
+```
+python app.py <host> [puerto]
+```
+
+Opciones principales:
+
+- `-c/--config`: ruta al archivo de configuración.
+- `-n/--name`: nombre del destino dentro del archivo de configuración.
+- `--port`: puerto alternativo para el destino seleccionado.
+- `--count`: número de OPTIONS a enviar (`0` para infinito).
+
+## Ejemplos
 
 ### Prueba rápida de OPTIONS
 
@@ -52,3 +105,31 @@ Atajos dentro de la interfaz:
 La pantalla muestra la latencia de las respuestas, contadores de éxito y fallo,
 un log de las últimas acciones y un indicador en color verde o rojo según el
 resultado del último OPTIONS.
+
+### Monitorización desde script
+
+```bash
+python - <<'PY'
+from sip_manager import SIPManager
+m = SIPManager('127.0.0.1', interval=5)
+m.send_request('OPTIONS', repeat=3)
+print(m.get_stats('OPTIONS'))
+PY
+```
+
+Este fragmento realiza tres OPTIONS y muestra estadísticas básicas.
+
+### Lanzar una llamada INVITE desde script
+
+```bash
+python - <<'PY'
+from sip_manager import SIPManager
+m = SIPManager('192.0.2.10')
+response, latency = m.send_request('INVITE')
+print('Respuesta:', response)
+print('Latencia:', latency)
+PY
+```
+
+Este ejemplo crea un `SIPManager`, envía un INVITE y muestra la respuesta y el
+tiempo empleado.


### PR DESCRIPTION
## Summary
- document Ubuntu setup and privileged port handling
- explain configuration fields and CLI parameters
- add monitoring and INVITE call examples

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b9572b5514832995b980f3751091a3