### PR TITLE
feat: SIP OPTIONS headers with rport, RTT metrics, CSV export and extended CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,14 +47,20 @@ siguientes campos:
 ### Parámetros de ejecución
 
 ```
-python app.py <host> [puerto]
+python app.py [host] [puerto]
+python app.py --dst <host> --dst-port <puerto> --protocol udp --count 1
 ```
 
 Opciones principales:
 
 - `-c/--config`: ruta al archivo de configuración.
 - `-n/--name`: nombre del destino dentro del archivo de configuración.
-- `--port`: puerto alternativo para el destino seleccionado.
+- `--dst`: host destino (alternativa a los posicionales).
+- `--dst-port`: puerto destino (por defecto 5060).
+- `--protocol`: `udp` o `tcp` (TCP no implementado).
+- `--interval`: segundos entre envíos.
+- `--timeout`: tiempo de espera de respuesta.
+- `--bind-ip`: IP de origen (opcional).
 - `--count`: número de OPTIONS a enviar (`0` para infinito).
 
 ## Ejemplos
@@ -62,8 +68,15 @@ Opciones principales:
 ### Prueba rápida de OPTIONS
 
 ```bash
-python app.py <host> [puerto]
+python app.py 10.1.72.188 5060 --count 2
 ```
+
+### Ejemplo con flags modernos
+
+```bash
+python app.py --dst 10.1.72.188 --dst-port 5060 --protocol udp --count 2 --interval 0.5 --timeout 2
+```
+El comando anterior crea/actualiza `dimitri_stats.csv` con las métricas.
 
 ### Usar archivo de configuración
 

--- a/app.py
+++ b/app.py
@@ -1,6 +1,12 @@
-import socket, sys, uuid, time
-import logging
+
 import argparse
+import csv
+import os
+import socket
+import sys
+import time
+import uuid
+from datetime import datetime
 
 from logging_conf import setup_logging
 from config import load_config
@@ -8,6 +14,7 @@ from sip_manager import SIPManager
 
 
 logger = setup_logging()
+
 
 def build_options(dst_host, dst_port, src_host="127.0.0.1", user="dimitri"):
     call_id = str(uuid.uuid4())
@@ -24,6 +31,8 @@ def build_options(dst_host, dst_port, src_host="127.0.0.1", user="dimitri"):
         f"Content-Length: 0\r\n\r\n"
     )
     return msg.encode()
+
+
 def send_options(dst_host, dst_port=5060, timeout=2):
     s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
     s.settimeout(timeout)
@@ -96,40 +105,87 @@ def send_invite(dst_host, dst_port=5060, timeout=2, headers=""):
         return False, latency, None, ""
     finally:
         s.close()
+
+
+def append_csv(filename, row):
+    exists = os.path.isfile(filename)
+    with open(filename, "a", newline="") as f:
+        writer = csv.writer(f)
+        if not exists:
+            writer.writerow(["ts_iso", "dst", "dst_port", "protocol", "status_code", "reason", "rtt_ms"])
+        writer.writerow(row)
+
+
+def run_monitor(manager, count, interval):
+    ok = other = to = 0
+    total = count
+    label = str(total) if total else "∞"
+    i = 0
+    try:
+        while total == 0 or i < total:
+            i += 1
+            start = datetime.utcnow().isoformat()
+            status, reason, rtt, _ = manager.send_options()
+            append_csv(
+                "dimitri_stats.csv",
+                [start, manager.remote_ip, manager.remote_port, manager.protocol.lower(), status or "", reason, f"{rtt:.3f}"],
+            )
+            if status is None:
+                print(f"[{i}/{label}] Timeout")
+                to += 1
+            elif status == 200:
+                print(f"[{i}/{label}] 200 OK {rtt:.0f} ms")
+                ok += 1
+            else:
+                print(f"[{i}/{label}] {status} {reason} {rtt:.0f} ms")
+                other += 1
+            if total == 0 or i < total:
+                time.sleep(interval)
+    except KeyboardInterrupt:
+        pass
+    print(f"Resumen: 200={ok} otros={other} timeouts={to}")
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Envía mensajes SIP OPTIONS")
     parser.add_argument("host", nargs="?", help="Host remoto si no se usa config")
     parser.add_argument("port", nargs="?", type=int, help="Puerto remoto", default=5060)
     parser.add_argument("-c", "--config", help="Archivo de configuración")
     parser.add_argument("-n", "--name", help="Nombre del destino en la config")
-    parser.add_argument("--port", dest="override_port", type=int, help="Puerto alternativo")
+    parser.add_argument("--dst", help="Host destino")
+    parser.add_argument("--dst-port", type=int, default=5060, help="Puerto destino")
+    parser.add_argument("--protocol", choices=["udp", "tcp"], default="udp")
+    parser.add_argument("--interval", type=float, default=1.0)
+    parser.add_argument("--timeout", type=float, default=1.0)
     parser.add_argument("--count", type=int, default=1, help="Número de OPTIONS a enviar (0=infinito)")
+    parser.add_argument("--bind-ip", help="IP de origen")
     args = parser.parse_args()
+
+    if args.protocol.lower() == "tcp":
+        print("TCP no implementado")
+        sys.exit(1)
 
     if args.config and args.name:
         destinations = load_config(args.config)
         if args.name not in destinations:
             parser.error(f"Destino {args.name} no encontrado en config")
         dst = destinations[args.name]
-        if args.override_port is not None:
-            dst.port = args.override_port
         manager = SIPManager(
             dst.ip,
-            dst.port,
-            protocol=dst.protocol,
-            interval=dst.interval,
-            timeout=dst.timeout,
-            retries=dst.retries,
+            args.dst_port if args.dst_port else dst.port,
+            protocol=args.protocol,
+            interval=args.interval if args.interval else dst.interval,
+            timeout=args.timeout if args.timeout else dst.timeout,
+            src_ip=args.bind_ip or "0.0.0.0",
         )
-        repeat = None if args.count == 0 else args.count
-        manager.send_request("OPTIONS", repeat=repeat)
+        run_monitor(manager, args.count, manager.interval)
     else:
-        host = args.host if args.host else "127.0.0.1"
-        port = args.override_port if args.override_port is not None else args.port
-        ok, latency, addr, data = send_options(host, port)
-        if ok:
-            logger.info("Respuesta de %s:%s", addr[0], addr[1])
-            print("Respuesta de", addr, "\n", data)
-        else:
-            logger.error("Timeout esperando respuesta de %s:%s", host, port)
-            print("Timeout esperando respuesta")
+        host = args.dst or args.host or "127.0.0.1"
+        port = args.port if args.port is not None else args.dst_port
+        manager = SIPManager(
+            host,
+            port,
+            protocol=args.protocol,
+            interval=args.interval,
+            timeout=args.timeout,
+            src_ip=args.bind_ip or "0.0.0.0",
+        )
+        run_monitor(manager, args.count, args.interval)

--- a/sip_manager.py
+++ b/sip_manager.py
@@ -19,6 +19,18 @@ setup_logging()
 logger = logging.getLogger(__name__)
 
 
+def detect_src_ip(dst_host, dst_port):
+    """Detect the outgoing source IP for the given destination."""
+    s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    try:
+        s.connect((dst_host, dst_port))
+        return s.getsockname()[0]
+    except OSError:
+        return "0.0.0.0"
+    finally:
+        s.close()
+
+
 class SIPManager:
     """Utility to build and send simple SIP requests."""
 
@@ -31,7 +43,7 @@ class SIPManager:
         timeout=2,
         retries=3,
         src_ip="0.0.0.0",
-        src_port=5060,
+        src_port=0,
         user="dimitri",
     ):
         ipaddress.ip_address(remote_ip)
@@ -41,33 +53,64 @@ class SIPManager:
         self.interval = interval
         self.timeout = timeout
         self.retries = retries
-        self.src_ip = src_ip
+        self.src_ip = src_ip or "0.0.0.0"
         self.src_port = src_port
         self.user = user
         self.stats = {
             "OPTIONS": {"sent": 0, "ok": 0, "timeout": 0, "latencies": []},
             "INVITE": {"sent": 0, "ok": 0, "timeout": 0, "latencies": []},
         }
+        if self.src_ip in ("0.0.0.0", ""):
+            self.src_ip = detect_src_ip(self.remote_ip, self.remote_port)
 
     def _new_call(self):
         call_id = str(uuid.uuid4())
         branch = "z9hG4bK" + call_id.replace("-", "")
         return call_id, branch
 
-    def build_options(self):
+    def build_options(self, src_ip=None):
+        src_ip = src_ip or self.src_ip
         call_id, branch = self._new_call()
         msg = (
             f"OPTIONS sip:{self.remote_ip} SIP/2.0\r\n"
-            f"Via: SIP/2.0/{self.protocol} {self.src_ip}:{self.src_port};branch={branch}\r\n"
-            f"Max-Forwards: 70\r\n"
-            f"From: <sip:{self.user}@{self.src_ip}>;tag={self.user}\r\n"
+            f"Via: SIP/2.0/UDP {src_ip}:0;branch={branch};rport\r\n"
+            "Max-Forwards: 70\r\n"
+            f"From: <sip:{self.user}@{src_ip}>;tag={self.user}\r\n"
             f"To: <sip:{self.remote_ip}>\r\n"
             f"Call-ID: {call_id}\r\n"
-            f"CSeq: 1 OPTIONS\r\n"
-            f"Contact: <sip:{self.user}@{self.src_ip}:{self.src_port}>\r\n"
-            f"Content-Length: 0\r\n\r\n"
+            "CSeq: 1 OPTIONS\r\n"
+            f"Contact: <sip:{self.user}@{src_ip}>\r\n"
+            "User-Agent: Dimitri-4000/0.1\r\n"
+            "Allow: INVITE, ACK, CANCEL, OPTIONS, BYE\r\n"
+            "Accept: application/sdp\r\n"
+            "Content-Length: 0\r\n\r\n"
         )
         return msg
+
+    def send_options(self):
+        if self.protocol != "UDP":
+            raise NotImplementedError("TCP no implementado")
+        msg = self.build_options().encode()
+        start = time.time()
+        try:
+            with open_udp_socket(
+                self.remote_ip,
+                self.remote_port,
+                local_port=0,
+                timeout=self.timeout,
+            ) as (sock, raddr):
+                udp_send(sock, msg, raddr)
+                data, _ = udp_receive(sock)
+            rtt = (time.time() - start) * 1000
+            text = data.decode(errors="ignore")
+            first = text.splitlines()[0] if text else ""
+            parts = first.split(" ", 2)
+            status = int(parts[1]) if len(parts) > 1 and parts[1].isdigit() else None
+            reason = parts[2] if len(parts) > 2 else ""
+            return status, reason, rtt, text
+        except (socket.timeout, OSError):
+            rtt = (time.time() - start) * 1000
+            return None, "", rtt, ""
 
     def build_invite(self, headers=None):
         """Build an INVITE request.


### PR DESCRIPTION
## Summary
- add source IP auto-detection and rport support in SIP OPTIONS headers
- measure RTT for each OPTIONS request and append metrics to `dimitri_stats.csv`
- extend CLI with modern flags while keeping `host [port]` compatibility

## Testing
- `python -m pytest`
- `python app.py 10.1.72.188 5060 --count 2`
- `python app.py --dst 10.1.72.188 --dst-port 5060 --protocol udp --count 2 --interval 0.5 --timeout 2`
- `python app.py -h`


------
https://chatgpt.com/codex/tasks/task_e_68b943551c1083298cd1b4a777d7df02