### PR TITLE
fix: clean exit after CANCEL with bounded wait and KeyboardInterrupt handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,13 @@ Intento con CANCEL por no respuesta:
 python app.py --invite --to sip:10.1.72.188 --dst 10.1.72.188 --ring-timeout 5 --talk-time 0
 ```
 
+### Timeout y CANCEL
+
+Cuando se supera `--ring-timeout` se envía un `CANCEL` y se espera hasta 5 s
+por las respuestas finales. Si llega `487 Request Terminated` se responde con
+`ACK` y la llamada termina con `result=canceled`. Si no llega nada en ese plazo,
+se finaliza con `result=canceled-timeout`.
+
 Limitaciones actuales: no soporta autenticación, PRACK ni manejo de SDP
 de respuesta.
 

--- a/app.py
+++ b/app.py
@@ -109,6 +109,8 @@ def main():
                 codec=args.codec,
                 rtp_port=args.rtp_port,
             )
+        except KeyboardInterrupt:
+            raise SystemExit(130)
         except OSError as e:
             logger.error(
                 f"No se pudo bindear UDP en {args.bind_ip or '0.0.0.0'}:{args.src_port}: {e}"


### PR DESCRIPTION
## Summary
- bound wait for final responses after CANCEL and ACK 487 to mark calls canceled or canceled-timeout
- exit gracefully on user interrupt in SIPManager and app entrypoint
- document CANCEL timeout behaviour in README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ba8d03ace48329ab3fc622b4121fb1