### PR TITLE
feat: basic SIP UAS for INVITE (100/180/200/ACK/BYE/CANCEL) with timers

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,25 @@ Ejemplo 2: solo responder:
   python app.py --service --reply-options --src-port 5060
   ```
 
+### UAS básico para INVITE
+
+El modo UAS responde a `INVITE` entrantes con `100/180/200` y gestiona el
+diálogo hasta `ACK/BYE`. Se habilita con `--uas`, lo que implica `--service`.
+
+Ejemplo 1: UAS que también responde a OPTIONS:
+
+```bash
+python app.py --uas --reply-options --bind-ip 10.1.64.18 --src-port 5060
+```
+
+Ejemplo 2: UAS con timbres y BYE automático tras 10 s:
+
+```bash
+python app.py --uas --uas-ring-delay 1 --uas-answer-after 3 --uas-talk-time 10 --bind-ip 10.1.64.18 --src-port 5062
+```
+
+Limitaciones: no soporta autenticación, PRACK ni Record-Route.
+
 ### Interfaz interactiva
 
 ```bash

--- a/tests/test_sip_manager.py
+++ b/tests/test_sip_manager.py
@@ -3,7 +3,14 @@ import sys
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
-from sip_manager import build_options, parse_headers, status_from_response
+from sip_manager import (
+    build_options,
+    build_response,
+    build_sdp,
+    build_bye,
+    parse_headers,
+    status_from_response,
+)
 
 
 def test_status_from_response_parses_code_and_reason():
@@ -31,3 +38,35 @@ def test_build_options_contains_mandatory_headers():
     assert "OPTIONS sip:example.com SIP/2.0" in text
     assert f"Call-ID: {call_id}" in text
     assert "Content-Length: 0" in text
+
+
+def test_build_response_generates_basic_sip_message():
+    resp = build_response(200, "OK", {"Via": "v1", "To": "<sip:b@1>"})
+    text = resp.decode()
+    assert text.startswith("SIP/2.0 200 OK")
+    assert "Via: v1" in text
+    assert "Content-Length: 0" in text
+
+
+def test_build_sdp_returns_valid_structure():
+    sdp = build_sdp("10.0.0.1", 4000, "pcmu")
+    assert "c=IN IP4 10.0.0.1" in sdp
+    assert "m=audio 4000 RTP/AVP" in sdp
+
+
+def test_build_bye_uses_dialog_fields():
+    dialog = {
+        "peer_uri": "sip:alice@10.0.0.1",
+        "from_uri": "<sip:alice@10.0.0.1>;tag=rtag",
+        "to_uri": "<sip:bob@10.0.0.2>",
+        "local_tag": "ltag",
+        "call_id": "cid",
+        "our_next_cseq": 1,
+        "local_ip": "10.0.0.2",
+        "local_port": 5060,
+    }
+    msg = build_bye(dialog)
+    text = msg.decode()
+    assert "BYE sip:alice@10.0.0.1 SIP/2.0" in text
+    assert "CSeq: 1 BYE" in text
+    assert "From: <sip:bob@10.0.0.2>;tag=ltag" in text


### PR DESCRIPTION
## Summary
- add `--uas` server for handling INVITE with 100/180/200/ACK/BYE/CANCEL
- implement timer-based retransmissions and BYE scheduling
- expose helpers to build SIP responses/SDP/BYE and document new flags

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ba91c950c0832981b583ce27b4ed4c