### PR TITLE
feat: UAC wait-until-BYE with optional max-call-time

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,21 @@ Intento con CANCEL por no respuesta:
 python app.py --invite --to sip:10.1.72.188 --dst 10.1.72.188 --ring-timeout 5 --talk-time 0
 ```
 
+### Finalización de la llamada
+
+Existen tres modos para terminar una llamada del lado UAC:
+
+1. `--talk-time N` (por defecto 5) – tras enviar `ACK` espera *N* segundos y
+   envía `BYE` propio.
+2. `--talk-time 0` sin `--wait-bye` – la llamada finaliza inmediatamente tras
+   el `ACK`, sin enviar `BYE`.
+3. `--wait-bye` – se mantiene la sesión activa hasta recibir un `BYE` remoto.
+   Con `--max-call-time N` se limita la espera; si se supera, se envía un `BYE`
+   propio y se cierra la llamada.
+
+En cualquiera de los casos, `Ctrl+C` durante la espera envía un único `BYE` y
+termina limpiamente con `result=aborted`.
+
 ### Timeout y CANCEL
 
 Cuando se supera `--ring-timeout` se envía un `CANCEL` y se espera hasta 5 s

--- a/app.py
+++ b/app.py
@@ -111,6 +111,17 @@ def parse_args():
     p.add_argument("--use-pai-asserted", action="store_true", help="Añadir P-Asserted-Identity")
     p.add_argument("--ring-timeout", type=float, default=15.0, help="Tiempo de espera antes de cancelar")
     p.add_argument("--talk-time", type=float, default=5.0, help="Tiempo de conversación antes de enviar BYE")
+    p.add_argument(
+        "--wait-bye",
+        action="store_true",
+        help="Si está, tras 200/ACK el UAC espera BYE remoto",
+    )
+    p.add_argument(
+        "--max-call-time",
+        type=float,
+        default=0.0,
+        help="Segundos; si se supera sin BYE, enviar BYE y cerrar (0=infinito)",
+    )
     p.add_argument("--codec", choices=["pcmu", "pcma"], default="pcmu", help="Codec SDP")
     p.add_argument("--rtp-port", type=int, default=40000, help="Puerto RTP local")
     p.add_argument("--rtcp", action="store_true", help="Abrir puerto RTCP")
@@ -180,6 +191,8 @@ def main():
                 cseq_start=args.cseq_start,
                 ring_timeout=args.ring_timeout,
                 talk_time=args.talk_time,
+                wait_bye=args.wait_bye,
+                max_call_time=args.max_call_time,
                 codec=args.codec,
                 rtp_port=args.rtp_port,
                 rtcp=args.rtcp,


### PR DESCRIPTION
## Summary
- add `--wait-bye` flag for UAC to remain in call until remote BYE
- allow optional `--max-call-time` to hang up after a limit
- keep RTP alive while waiting and handle SIGINT with single BYE

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bec426b6d88329af308e3fc2eccdee