### PR TITLE
feat: SIP Digest auth (401/407) for INVITE and BYE

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ Ejemplo 2: UAS con timbres y BYE automático tras 10 s:
 python app.py --uas --uas-ring-delay 1 --uas-answer-after 3 --uas-talk-time 10 --bind-ip 10.1.64.18 --src-port 5062
 ```
 
-Limitaciones: no soporta autenticación, PRACK ni Record-Route.
+Limitaciones: no soporta PRACK ni Record-Route.
 
 El `Contact` del `200 OK` incluye siempre el puerto local real. El cliente
 envía el `ACK` al host:puerto indicado en ese `Contact` (si no trae puerto, se
@@ -198,6 +198,12 @@ Llamada completa y colgar a los 5 s:
 python app.py --invite --to sip:10.1.72.188 --dst 10.1.72.188 --dst-port 5060 --src-port 5062 --talk-time 5 --ring-timeout 15
 ```
 
+Autenticación Digest básica:
+
+```bash
+python app.py --invite --to sip:10.1.72.188 --dst 10.1.72.188 --auth-user 1000 --auth-pass secret
+```
+
 Intento con CANCEL por no respuesta:
 
 ```bash
@@ -226,7 +232,7 @@ por las respuestas finales. Si llega `487 Request Terminated` se responde con
 `ACK` y la llamada termina con `result=canceled`. Si no llega nada en ese plazo,
 se finaliza con `result=canceled-timeout`.
 
-Limitaciones actuales: no soporta autenticación, PRACK ni manejo de SDP
+Limitaciones actuales: no soporta PRACK ni manejo de SDP
 de respuesta.
 
 ### Monitorización desde script

--- a/app.py
+++ b/app.py
@@ -135,6 +135,13 @@ def parse_args():
         default=2.0,
         help="Segundos entre logs de métricas RTP",
     )
+    p.add_argument("--auth-user", help="Usuario para autenticación Digest")
+    p.add_argument("--auth-pass", help="Contraseña para autenticación Digest")
+    p.add_argument("--auth-realm", help="Realm para autenticación Digest")
+    p.add_argument(
+        "--auth-username",
+        help="Username para Digest si distinto del número de usuario",
+    )
     # Compatibilidad con la CLI antigua: host [port]
     p.add_argument("host", nargs="?", help="Destino (compat)")
     p.add_argument("port", nargs="?", type=int, help="Puerto destino (compat)")
@@ -185,6 +192,10 @@ def main():
                 pai=args.pai,
                 use_pai=args.use_pai,
                 use_pai_asserted=args.use_pai_asserted,
+                auth_user=args.auth_user,
+                auth_pass=args.auth_pass,
+                auth_realm=args.auth_realm,
+                auth_username=args.auth_username,
                 bind_ip=args.bind_ip,
                 bind_port=args.src_port,
                 timeout=args.timeout,


### PR DESCRIPTION
## Summary
- add Digest auth helpers and INVITE/BYE retry with Authorization headers
- expose `--auth-*` CLI flags to configure credentials
- document Digest usage example

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bec7bbac9083298213ce609cd047bb