### PR TITLE
feat: offer PCMU+PCMA and negotiate selected codec; RTP send/recv per PT

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,17 +272,18 @@ tiempo empleado.
 
 ## RTP básico
 
-Soporte RTP sencillo está disponible para los códecs PCMU/PCMA. No incluye
-SRTP ni ICE, por lo que en redes con NAT se requiere abrir puertos o habilitar
-`--symmetric-rtp`.
+Soporte RTP sencillo está disponible para los códecs PCMU/PCMA. Se pueden
+ofertar varios códecs con `--codecs` (por defecto `pcmu,pcma`) y forzar la
+preferencia local con `--prefer`. No incluye SRTP ni ICE, por lo que en redes
+con NAT se requiere abrir puertos o habilitar `--symmetric-rtp`.
 
 Ejemplo de bucle local (UAS/UAC en la misma máquina):
 
 ```bash
 UAS: python app.py --uas --bind-ip 192.168.0.137 --src-port 5062 \
-     --uas-answer-after 1 --rtp-port 40000 --codec pcmu --rtp-stats-every 1
+     --uas-answer-after 1 --rtp-port 40000 --codecs pcma,pcmu --rtp-stats-every 1
 UAC: python app.py --invite --dst 192.168.0.137 --dst-port 5062 --src-port 5060 \
-     --rtp-port 42000 --codec pcmu --rtp-tone 1000 --rtp-stats-every 1
+     --rtp-port 42000 --codecs pcmu,pcma --rtp-tone 1000 --rtp-stats-every 1
 ```
 
 Se puede guardar el audio recibido en un WAV con `--rtp-save-wav`.

--- a/rtp.py
+++ b/rtp.py
@@ -253,6 +253,10 @@ class RtpSession:
                 continue
             seq = struct.unpack("!H", data[2:4])[0]
             ts = struct.unpack("!I", data[4:8])[0]
+            pt = data[1] & 0x7F
+            if pt not in (0, 8):
+                logger.warning("Unsupported PT=%s", pt)
+                continue
             payload = data[12:]
             arrival = time.time()
             self.recv_packets += 1
@@ -272,7 +276,7 @@ class RtpSession:
             if self.wav_file and payload:
                 pcm = (
                     ulaw_decode_to_pcm16(payload)
-                    if self.pt == 0
+                    if pt == 0
                     else alaw_decode_to_pcm16(payload)
                 )
                 try:

--- a/sdp.py
+++ b/sdp.py
@@ -1,22 +1,42 @@
-"""Helpers for SDP generation and parsing."""
+'''Helpers for SDP generation and parsing supporting PCMU and PCMA.'''
+
+from __future__ import annotations
+
+from typing import Dict, List
+
+# Mapping between codec names and payload types
+PT_FROM_CODEC_NAME = {"pcmu": 0, "pcma": 8}
+CODEC_NAME_FROM_PT = {v: k.upper() for k, v in PT_FROM_CODEC_NAME.items()}
 
 
-def build_sdp(local_ip: str, rtp_port: int, pt: int) -> str:
-    codec = "PCMU" if pt == 0 else "PCMA"
-    return (
-        "v=0\r\n"
-        f"o=dimitri 0 0 IN IP4 {local_ip}\r\n"
-        "s=Dimitri-4000\r\n"
-        f"c=IN IP4 {local_ip}\r\n"
-        "t=0 0\r\n"
-        f"m=audio {rtp_port} RTP/AVP {pt}\r\n"
-        f"a=rtpmap:{pt} {codec}/8000\r\n"
-        "a=sendrecv\r\n"
-    )
+def build_sdp(local_ip: str, rtp_port: int, pts: List[int]) -> bytes:
+    """Return minimal SDP offer/answer advertising the given payload types."""
+    pt_list = " ".join(str(pt) for pt in pts)
+    lines = [
+        "v=0\r\n",
+        f"o=dimitri 0 0 IN IP4 {local_ip}\r\n",
+        "s=Dimitri-4000\r\n",
+        f"c=IN IP4 {local_ip}\r\n",
+        "t=0 0\r\n",
+        f"m=audio {rtp_port} RTP/AVP {pt_list}\r\n",
+    ]
+    for pt in pts:
+        codec = CODEC_NAME_FROM_PT.get(pt, str(pt))
+        lines.append(f"a=rtpmap:{pt} {codec}/8000\r\n")
+    lines.append("a=sendrecv\r\n")
+    return "".join(lines).encode()
 
 
-def parse_sdp(text: str) -> tuple[str | None, int | None, int | None]:
-    ip = port = pt = None
+def parse_sdp(body: bytes | str) -> Dict:
+    """Parse minimal SDP returning connection info and codec mappings."""
+    if isinstance(body, bytes):
+        text = body.decode(errors="ignore")
+    else:
+        text = body
+    ip = None
+    port = None
+    pts: List[int] = []
+    rtpmap: Dict[int, str] = {}
     for line in text.splitlines():
         if line.startswith("c=") and ip is None:
             parts = line.split()
@@ -27,8 +47,16 @@ def parse_sdp(text: str) -> tuple[str | None, int | None, int | None]:
             if len(parts) >= 4:
                 try:
                     port = int(parts[1])
-                    pt = int(parts[3])
+                    pts = [int(p) for p in parts[3:] if p.isdigit()]
                 except ValueError:
                     pass
-    return ip, port, pt
+        elif line.startswith("a=rtpmap:"):
+            try:
+                p = line.split(None, 1)[0]
+                pt = int(p.split(":", 1)[1])
+                codec = line.split(None, 1)[1].split("/", 1)[0].upper()
+                rtpmap[pt] = codec
+            except Exception:
+                continue
+    return {"ip": ip, "audio_port": port, "pts": pts, "rtpmap": rtpmap}
 

--- a/tests/test_sip_manager.py
+++ b/tests/test_sip_manager.py
@@ -9,7 +9,6 @@ import pytest
 from sip_manager import (
     build_options,
     build_response,
-    build_sdp,
     build_bye,
     build_bye_request,
     parse_headers,
@@ -21,6 +20,7 @@ from sip_manager import (
     build_digest_auth,
     _route_set_from_record_route,
 )
+from sdp import build_sdp, parse_sdp
 
 
 def test_status_from_response_parses_code_and_reason():
@@ -59,9 +59,19 @@ def test_build_response_generates_basic_sip_message():
 
 
 def test_build_sdp_returns_valid_structure():
-    sdp = build_sdp("10.0.0.1", 4000, 0)
-    assert "c=IN IP4 10.0.0.1" in sdp
-    assert "m=audio 4000 RTP/AVP" in sdp
+    sdp = build_sdp("10.0.0.1", 4000, [0])
+    assert b"c=IN IP4 10.0.0.1" in sdp
+    assert b"m=audio 4000 RTP/AVP 0" in sdp
+
+
+def test_parse_sdp_parses_pts_and_rtpmap():
+    sdp = build_sdp("10.0.0.1", 4000, [0, 8])
+    info = parse_sdp(sdp)
+    assert info["ip"] == "10.0.0.1"
+    assert info["audio_port"] == 4000
+    assert info["pts"] == [0, 8]
+    assert info["rtpmap"][0] == "PCMU"
+    assert info["rtpmap"][8] == "PCMA"
 
 
 def test_build_bye_uses_dialog_fields():


### PR DESCRIPTION
## Summary
- add `--codecs`, `--codec` alias and `--prefer` to configure PCMU/PCMA order and preference
- negotiate codec from SDP offers/answers, returning 488 when no common codec
- send and receive RTP using negotiated payload type, decoding packets by PT

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68becdb213208329a8abc908a43f810a