### PR TITLE
Reuse GUI shared socket for UAC and generator

### DIFF
--- a/gui_tk.py
+++ b/gui_tk.py
@@ -701,6 +701,8 @@ class App(tk.Tk):
         cfg = self.get_config()
         if not cfg:
             return
+        sock = self._ensure_shared_sock()
+        self.sm = SIPManager(sock=sock)
         t = threading.Thread(target=call_worker, args=(cfg, self.event_q, self.sm))
         t.daemon = True
         t.start()
@@ -714,6 +716,8 @@ class App(tk.Tk):
         cfg = self.get_config()
         if not cfg:
             return
+        sock = self._ensure_shared_sock()
+        self.sm = SIPManager(sock=sock)
         t = threading.Thread(target=load_worker, args=(cfg, self.event_q, self.stop_event, self.sm))
         t.daemon = True
         t.start()


### PR DESCRIPTION
## Summary
- Use GUI's shared UDP socket for UAC calls and load generator
- Extend `SIPManager` to accept an existing socket and avoid closing it
- Handle destination port not listening with clear log messages

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c1861d98648329bf2e882aaecf73ac