### PR TITLE
Add helper builders for SIP responses

### DIFF
--- a/app.py
+++ b/app.py
@@ -29,6 +29,11 @@ from sip_manager import (
     build_bye,
     parse_headers,
     status_from_response,
+    build_cancel,
+    build_trying,
+    build_ringing,
+    build_200,
+    build_487,
 )
 from sdp import build_sdp, parse_sdp, PT_FROM_CODEC_NAME, CODEC_NAME_FROM_PT
 from rtp import RtpSession

--- a/gui_tk.py
+++ b/gui_tk.py
@@ -9,7 +9,17 @@ import tkinter as tk
 from tkinter import ttk, messagebox, filedialog
 from types import SimpleNamespace
 
-from sip_manager import SIPManager, build_response, parse_headers, build_options
+from sip_manager import (
+    SIPManager,
+    build_response,
+    parse_headers,
+    build_options,
+    build_cancel,
+    build_trying,
+    build_ringing,
+    build_200,
+    build_487,
+)
 from app import run_load_generator
 
 # Configuration persisted in user home directory

--- a/sip_manager.py
+++ b/sip_manager.py
@@ -337,6 +337,26 @@ def build_response(
         lines.append("Content-Length: 0\r\n\r\n")
         return "".join(lines).encode()
 
+
+def build_trying(headers: dict) -> bytes:
+    """Shortcut to build a 100 Trying response."""
+    return build_response(100, "Trying", headers)
+
+
+def build_ringing(headers: dict) -> bytes:
+    """Shortcut to build a 180 Ringing response."""
+    return build_response(180, "Ringing", headers)
+
+
+def build_200(headers: dict, body: bytes | str = b"") -> bytes:
+    """Shortcut to build a 200 OK response."""
+    return build_response(200, "OK", headers, body)
+
+
+def build_487(headers: dict) -> bytes:
+    """Shortcut to build a 487 Request Terminated response."""
+    return build_response(487, "Request Terminated", headers)
+
 def build_bye(dialog: dict) -> bytes:
     """Build a BYE request from stored dialog information (UAS side)."""
     branch = "z9hG4bK" + uuid.uuid4().hex


### PR DESCRIPTION
## Summary
- add convenience SIP response builders to `sip_manager`
- re-export new builders from app and GUI modules

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c18f75f91c8329b22475bdb27467c0