### PR TITLE
fix: improve BYE handling and GUI state updates

### DIFF
--- a/gui_tk.py
+++ b/gui_tk.py
@@ -975,15 +975,17 @@ class App(tk.Tk):
         sm = getattr(self, "_sm_for_gui", None)
         if sm:
             sm.bye_all_uac()
+        # ensure the call button is re-enabled even if the worker got stuck
+        self._uac_running = False
         self.after(0, self._refresh_buttons_state)
-        self.log("BYE UAC enviado para todos los diálogos.")
+        self.log("BYE UAC enviado.")
 
     def on_bye_all_uas(self):
         sm = getattr(self, "_sm_for_gui", None)
         if sm:
             sm.bye_all_uas()
         self.after(0, self._refresh_buttons_state)
-        self.log("BYE UAS enviado para todos los diálogos.")
+        self.log("BYE UAS enviado.")
 
     def save_log(self):
         path = filedialog.asksaveasfilename(defaultextension=".log")


### PR DESCRIPTION
## Summary
- log BYE requests for each dialog and stop RTP safely when terminating
- refresh GUI button state after sending BYE and reset UAC running flag

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c29373a9e08329aad242513a96bd22