### PR TITLE
fix(generator): use rtp_send_silence consistently; add backward-compat alias; prevent AttributeError

### DIFF
--- a/app.py
+++ b/app.py
@@ -80,6 +80,10 @@ def write_csv_row(path, row, header=None):
         w.writerow(row)
 
 
+def _get_flag(obj, name):
+    return bool(getattr(obj, name, False))
+
+
 def send_options_periodic(
     bind_ip: str | None,
     src_port: int,
@@ -438,7 +442,10 @@ def run_load_generator(args, sip_manager, stats_cb=None):
                     rtp_port_forced=True,
                     rtcp=args.rtcp,
                     tone_hz=args.rtp_tone,
-                    send_silence=(args.rtp_send_silence or args.rtp_always_silence),
+                    send_silence=(
+                        _get_flag(args, "rtp_send_silence")
+                        or _get_flag(args, "rtp_always_silence")
+                    ),
                     symmetric=args.symmetric_rtp,
                     stats_interval=args.rtp_stats_every,
                 )
@@ -655,7 +662,10 @@ def main():
                 rtp_port_forced=args.rtp_port_forced,
                 rtcp=args.rtcp,
                 tone_hz=args.rtp_tone,
-                send_silence=(args.rtp_send_silence or args.rtp_always_silence),
+                send_silence=(
+                    _get_flag(args, "rtp_send_silence")
+                    or _get_flag(args, "rtp_always_silence")
+                ),
                 symmetric=args.symmetric_rtp,
                 save_wav=args.rtp_save_wav,
                 stats_interval=args.rtp_stats_every,
@@ -1009,7 +1019,10 @@ def main():
                                         rtp.rtcp = args.rtcp
                                         rtp.tone_hz = args.rtp_tone
                                         rtp.send_silence = (
-                                            (args.rtp_send_silence or args.rtp_always_silence)
+                                            (
+                                                _get_flag(args, "rtp_send_silence")
+                                                or _get_flag(args, "rtp_always_silence")
+                                            )
                                             and not args.rtp_tone
                                         )
                                         rtp.stats_interval = args.rtp_stats_every

--- a/gui_tk.py
+++ b/gui_tk.py
@@ -1398,13 +1398,14 @@ def load_worker(cfg, event_q, stop_event, sm):
             codecs=[(0, "PCMU")],
             rtcp=False,
             rtp_tone=None,
-            rtp_send_silence=False,
+            rtp_send_silence=bool(cfg.get("send_silence", False)),
             symmetric_rtp=False,
             rtp_stats_every=cfg.get("rtp_stats_every", 2.0),
             calls=cfg.get("calls", 1),
             rate=cfg.get("rate", 1.0),
             max_active=cfg.get("max_active", 1),
         )
+        args.rtp_always_silence = args.rtp_send_silence
         if (
             args.calls < 1
             or not args.dst


### PR DESCRIPTION
## Summary
- add `_get_flag` helper and use it to check new/legacy RTP silence flags
- set `send_silence` from both `rtp_send_silence` and `rtp_always_silence`
- ensure GUI sets `rtp_send_silence` from checkbox and provides `rtp_always_silence` alias

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c4108756008329a694f8c36d45b121