### PR TITLE
fix(uac): race-safe CANCEL and ACK/BYE handling

### DIFF
--- a/gui_tk.py
+++ b/gui_tk.py
@@ -473,6 +473,10 @@ class App(tk.Tk):
                     except Exception:
                         pass
                     try:
+                        self.bye_all_uac_btn.config(state="disabled")
+                    except Exception:
+                        pass
+                    try:
                         self.call_btn.config(state="normal")
                     except Exception:
                         pass
@@ -1376,7 +1380,7 @@ def call_worker(cfg, event_q, sm):
     except Exception as exc:  # noqa: BLE001
         event_q.put(("log", f"Call error: {exc}"))
         result = "error"
-    if result in ("answered", "remote-bye", "max-time-bye"):
+    if result in ("answered", "remote-bye", "max-time-bye", "canceled-after-200"):
         counters["established"] += 1
     if result.startswith("rejected(4") or result.startswith("busy"):
         counters["failed_4xx"] += 1


### PR DESCRIPTION
## Summary
- add explicit UAC call state tracking in `SIPManager` with ring timers, cancel/confirm flags and ACK/BYE handling after 2xx
- ensure RTP only starts when codecs intersect, lock per-call execution, and stop timers/rtp on teardown
- propagate new `canceled-after-200` result to load/GUI stats and fix GUI BYE button states when calls end

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c92f8b53b4832996f3a01a1c88578f