### PR TITLE
Reuse single SIP UDP transport across UAC/UAS and generator

### DIFF
--- a/app.py
+++ b/app.py
@@ -8,6 +8,7 @@ import time
 import uuid
 import sys
 import errno
+import queue
 import threading
 import secrets
 from datetime import datetime, UTC
@@ -53,6 +54,7 @@ from sdp import (
 from rtp import RtpSession
 from core.reactor import Reactor
 from core.options_monitor import OptionsMonitor, register_options_responder
+from socket_handler import SipTransport, get_sip_transport
 
 PROHIBITED = {"via", "from", "to", "call-id", "cseq", "contact", "content-length"}
 
@@ -257,7 +259,18 @@ def build_bye_simple(
     return msg.encode()
 
 
-def generator_call_worker(sock, local_ip, dst_addr, base_args, per_call_args, stats_cb=None):
+def generator_call_worker(
+    transport: SipTransport,
+    sip_ip: str,
+    sip_port: int,
+    sdp_ip: str,
+    dst_addr,
+    base_args,
+    per_call_args,
+    call_id: str,
+    rx_queue,
+    stats_cb=None,
+):
     """
     sock: UDP ya bindeado (puerto src)
     dst_addr: (ip, port) destino
@@ -266,7 +279,6 @@ def generator_call_worker(sock, local_ip, dst_addr, base_args, per_call_args, st
     """
     log = logging.getLogger("load-call")
     start_ts = time.time()
-    call_id = f"{uuid.uuid4()}"
     local_tag = secrets.token_hex(4)
     dialog = SIPDialog(call_id, local_tag)
 
@@ -281,7 +293,7 @@ def generator_call_worker(sock, local_ip, dst_addr, base_args, per_call_args, st
         sdp_mode = getattr(base_args, "sdp_direction", "sendrecv")
     dialog.mode = sdp_mode
     offer_sdp = build_sdp(
-        local_ip,
+        sdp_ip,
         per_call_args.rtp_port,
         codecs,
         session_extras=getattr(base_args, "sdp_session_extras", []),
@@ -293,12 +305,12 @@ def generator_call_worker(sock, local_ip, dst_addr, base_args, per_call_args, st
     branch = "z9hG4bK" + uuid.uuid4().hex
     dialog.branch = branch
     contact_user = getattr(per_call_args, "from_user", None) or "u"
-    local_port = getattr(per_call_args, "src_port", None) or sock.getsockname()[1]
+    local_port = sip_port
     invite = build_invite(
         request_uri=per_call_args.to_uri,
         from_uri=per_call_args.from_uri,
         to_uri=per_call_args.to_uri,
-        local_ip=local_ip,
+        local_ip=sip_ip,
         local_port=local_port,
         call_id=call_id,
         cseq=cseq,
@@ -308,7 +320,7 @@ def generator_call_worker(sock, local_ip, dst_addr, base_args, per_call_args, st
         contact_user=contact_user,
         extra_headers=getattr(per_call_args, "extra_headers_list", []),
     )
-    sock.sendto(invite, dst_addr)
+    transport.sendto(invite, dst_addr)
 
     ring_timeout = float(getattr(base_args, "ring_timeout", 10.0))
     ring_deadline = time.time() + ring_timeout
@@ -322,14 +334,13 @@ def generator_call_worker(sock, local_ip, dst_addr, base_args, per_call_args, st
     t_end = time.time() + talk_time if talk_time > 0 else None
     max_end = time.time() + max_call_time if max_call_time > 0 else None
 
-    sock.settimeout(0.5)
     while True:
         now = time.time()
         if not established and now > ring_deadline:
             cancel = build_cancel(
                 request_uri=per_call_args.to_uri,
                 to_uri=per_call_args.to_uri,
-                local_ip=local_ip,
+                local_ip=sip_ip,
                 local_port=local_port,
                 from_uri=per_call_args.from_uri,
                 from_display=None,
@@ -339,7 +350,7 @@ def generator_call_worker(sock, local_ip, dst_addr, base_args, per_call_args, st
                 branch=branch,
                 contact_user=contact_user,
             )
-            sock.sendto(cancel, dst_addr)
+            transport.sendto(cancel, dst_addr)
             log.info("CANCEL enviado call-id=%s", call_id)
             result = "canceled"
             break
@@ -357,7 +368,7 @@ def generator_call_worker(sock, local_ip, dst_addr, base_args, per_call_args, st
                 to_tag=dialog.remote_tag,
                 contact_user=contact_user,
             )
-            sock.sendto(bye, dst_addr)
+            transport.sendto(bye, dst_addr)
             bye_sent = True
             result = "max-time-bye"
 
@@ -374,13 +385,13 @@ def generator_call_worker(sock, local_ip, dst_addr, base_args, per_call_args, st
                 to_tag=dialog.remote_tag,
                 contact_user=contact_user,
             )
-            sock.sendto(bye, dst_addr)
+            transport.sendto(bye, dst_addr)
             bye_sent = True
             result = "max-time-bye"
 
         try:
-            data, addr = sock.recvfrom(65535)
-        except socket.timeout:
+            data, addr = rx_queue.get(timeout=0.5)
+        except queue.Empty:
             continue
         except OSError:
             result = "aborted"
@@ -402,7 +413,7 @@ def generator_call_worker(sock, local_ip, dst_addr, base_args, per_call_args, st
             ack = build_ack(
                 request_uri=per_call_args.to_uri,
                 to_header=headers.get("to", f"<{per_call_args.to_uri}>"),
-                local_ip=local_ip,
+                local_ip=sip_ip,
                 local_port=local_port,
                 from_uri=per_call_args.from_uri,
                 from_display=None,
@@ -411,7 +422,7 @@ def generator_call_worker(sock, local_ip, dst_addr, base_args, per_call_args, st
                 tag=local_tag,
                 contact_user=contact_user,
             )
-            sock.sendto(ack, dst_addr)
+            transport.sendto(ack, dst_addr)
             dialog.ack_sent = True
             established = True
             dialog.established = True
@@ -422,7 +433,7 @@ def generator_call_worker(sock, local_ip, dst_addr, base_args, per_call_args, st
                 try:
                     start_rtp_for_dialog(
                         dialog,
-                        local_ip,
+                        sdp_ip,
                         per_call_args.rtp_port,
                         pt_prefer,
                         getattr(base_args, "rtp_tone", 0) or 0,
@@ -451,7 +462,7 @@ def generator_call_worker(sock, local_ip, dst_addr, base_args, per_call_args, st
         if msg_start.startswith("BYE "):
             resp = build_response_ok_from_request(data)
             if resp:
-                sock.sendto(resp, addr)
+                transport.sendto(resp, addr)
             stop_rtp_for_dialog(dialog)
             log.info("BYE remoto atendido call-id=%s", call_id)
             result = "remote-bye" if established else "aborted"
@@ -913,8 +924,6 @@ def make_per_call_args(
     i,
     fixed_numbers=False,
     num_step=1,
-    src_port_base=None,
-    src_port_step=0,
     rtp_port_base=None,
     rtp_port_step=2,
 ):
@@ -937,8 +946,6 @@ def make_per_call_args(
             )
 
     # Puertos
-    if src_port_base:
-        a.src_port = int(src_port_base) + i * int(src_port_step or 0)
     if rtp_port_base:
         a.rtp_port = int(rtp_port_base) + i * int(rtp_port_step or 2)
 
@@ -953,7 +960,7 @@ def make_per_call_args(
     return a
 
 
-def run_load_generator(args, sip_manager, stats_cb=None):
+def run_load_generator(args, sip_manager, sip_transport: SipTransport, stats_cb=None):
     """Generate many calls with controlled rate and incremental parameters.
 
     Parameters
@@ -1060,18 +1067,6 @@ def run_load_generator(args, sip_manager, stats_cb=None):
     def format_num(num):
         return str(num).zfill(pad_width) if pad_width > 0 else str(num)
 
-    shared_sock = None
-    if not args.src_port_base:
-        try:
-            shared_sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-            shared_sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-            shared_sock.bind((args.bind_ip or "0.0.0.0", getattr(args, "src_port", 0) or 0))
-        except OSError as e:
-            logger.error(
-                f"No se pudo bindear UDP en {args.bind_ip or '0.0.0.0'}:{getattr(args, 'src_port', 0)}: {e}"
-            )
-            raise SystemExit(1)
-
     def _resolve_local_ip(sock):
         if args.bind_ip and args.bind_ip != "0.0.0.0":
             return args.bind_ip
@@ -1085,15 +1080,37 @@ def run_load_generator(args, sip_manager, stats_cb=None):
                 local_ip = sock.getsockname()[0]
         return local_ip
 
+    sip_ip = sip_transport.bind_ip
+    sip_port = sip_transport.src_port
+
+    call_queues: dict[str, queue.Queue] = {}
+    rx_stop = threading.Event()
+
+    def rx_loop():
+        while not rx_stop.is_set():
+            try:
+                data, addr = sip_transport.recvfrom()
+            except socket.timeout:
+                continue
+            except OSError:
+                break
+            _, headers = parse_headers(data)
+            call_id = headers.get("call-id")
+            if not call_id:
+                continue
+            with lock:
+                q = call_queues.get(call_id)
+            if q:
+                q.put((data, addr))
+
     def worker(i):
         nonlocal counters
+        local_ip = _resolve_local_ip(sip_transport.sock)
         call_args = make_per_call_args(
             args,
             i,
             fixed_numbers=fixed_numbers,
             num_step=step,
-            src_port_base=args.src_port_base,
-            src_port_step=args.src_port_step,
             rtp_port_base=args.rtp_port_base,
             rtp_port_step=args.rtp_port_step,
         )
@@ -1139,13 +1156,11 @@ def run_load_generator(args, sip_manager, stats_cb=None):
                 active.discard(threading.current_thread())
             return
 
-        src_port = getattr(call_args, "src_port", 0) if args.src_port_base else 0
         rtp_port = getattr(call_args, "rtp_port", args.rtp_port_base)
         if rtp_port % 2:
             rtp_port += 1
         ts = datetime.now(UTC).isoformat()
         call_args.rtp_port = rtp_port
-        call_args.src_port = src_port if src_port else None
         send_silence = bool(
             getattr(args, "rtp_send_silence", False)
             or getattr(args, "rtp_always_silence", False)
@@ -1154,24 +1169,26 @@ def run_load_generator(args, sip_manager, stats_cb=None):
         call_args.codecs = args.codecs
         call_args.extra_headers_list = call_args.extra_headers_list or base_extra_headers
 
+        call_id = f"{uuid.uuid4()}"
+        call_id_key = call_id
         try:
-            if call_args.src_port:
-                s_worker = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-                s_worker.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-                s_worker.bind((args.bind_ip or "0.0.0.0", int(call_args.src_port)))
-            else:
-                s_worker = shared_sock
-            local_ip = _resolve_local_ip(s_worker)
+            rx_queue: queue.Queue = queue.Queue()
+            with lock:
+                call_queues[call_id_key] = rx_queue
             call_id, result, setup_ms, dialog = generator_call_worker(
-                s_worker,
+                sip_transport,
+                sip_ip,
+                sip_port,
                 local_ip,
                 (dst, int(dport)),
                 args,
                 call_args,
+                call_id_key,
+                rx_queue,
                 stats_cb=stats_cb,
             )
         except OSError as e:
-            call_id = ""
+            call_id = call_id_key
             result = f"error({getattr(e, 'errno', 'socket')})"
             setup_ms = 0
         except Exception as e:
@@ -1181,15 +1198,12 @@ def run_load_generator(args, sip_manager, stats_cb=None):
                 active.discard(threading.current_thread())
             return
         finally:
-            if call_args.src_port and s_worker:
-                try:
-                    s_worker.close()
-                except Exception:
-                    pass
+            with lock:
+                call_queues.pop(call_id_key, None)
 
         write_csv_row(
             "calls_summary.csv",
-            [ts, call_id, from_uri, final_to_uri, src_port, rtp_port, setup_ms, result],
+            [ts, call_id, from_uri, final_to_uri, sip_port, rtp_port, setup_ms, result],
             [
                 "ts_start",
                 "call_id",
@@ -1240,6 +1254,8 @@ def run_load_generator(args, sip_manager, stats_cb=None):
             if stop.wait(2):
                 break
 
+    rx_thread = threading.Thread(target=rx_loop, daemon=True)
+    rx_thread.start()
     printer_t = threading.Thread(target=printer, daemon=True)
     printer_t.start()
 
@@ -1269,11 +1285,8 @@ def run_load_generator(args, sip_manager, stats_cb=None):
         t.join()
     stop.set()
     printer_t.join()
-    if shared_sock:
-        try:
-            shared_sock.close()
-        except Exception:
-            pass
+    rx_stop.set()
+    rx_thread.join(timeout=1.0)
     if stats_cb:
         with lock:
             final = counters.copy()
@@ -1328,8 +1341,9 @@ def main():
     if args.load:
         if not (args.dst or args.host):
             raise SystemExit("Falta destino: usa --dst 10.0.0.1")
-        sm = SIPManager(protocol=args.protocol)
-        run_load_generator(args, sm)
+        sip_transport = get_sip_transport(args.bind_ip or "0.0.0.0", args.src_port)
+        sm = SIPManager(protocol=args.protocol, transport=sip_transport)
+        run_load_generator(args, sm, sip_transport)
         return
 
     if args.uas and not args.service:
@@ -1357,7 +1371,8 @@ def main():
         to_uri = args.to_uri
         if not to_uri and args.to:
             to_uri = args.to if args.to.startswith("sip:") else f"sip:{args.to}"
-        sm = SIPManager(protocol=args.protocol)
+        sip_transport = get_sip_transport(args.bind_ip or "0.0.0.0", args.src_port)
+        sm = SIPManager(protocol=args.protocol, transport=sip_transport)
         extra_headers = (
             getattr(args, "extra_headers_list", None)
             or getattr(args, "extra_headers", [])
@@ -1431,9 +1446,8 @@ def main():
             raise SystemExit("En modo servicio se requiere --dst o --reply-options")
 
         try:
-            sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-            sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-            sock.bind(((args.bind_ip or "0.0.0.0"), args.src_port or 0))
+            sip_transport = get_sip_transport(args.bind_ip or "0.0.0.0", args.src_port)
+            sock = sip_transport.sock
         except OSError as e:
             logger.error(
                 f"No se pudo bindear UDP en {args.bind_ip or '0.0.0.0'}:{args.src_port}: {e}"
@@ -1441,12 +1455,14 @@ def main():
             raise SystemExit(1)
 
         local_ip = args.bind_ip or sock.getsockname()[0]
-        local_port = sock.getsockname()[1]
+        local_port = sip_transport.src_port
+        sip_ip = sip_transport.bind_ip
         local_pts = [pt for pt, _ in args.codecs if pt in (0, 8)]
         if not local_pts:
             local_pts = [0, 8]
         first_pt = local_pts[0]
-        contact_ip = args.advertised_ip or local_ip
+        contact_ip = sip_ip
+        sdp_ip = args.advertised_ip or local_ip
         user = "dimitri"
         tag_local = uuid.uuid4().hex[:8]
         pending = []  # call_id -> send_time
@@ -1535,17 +1551,7 @@ def main():
                         else:
                             if "tag=" not in to.lower():
                                 to = f"{to};tag={tag_local}"
-                            if args.bind_ip:
-                                contact_ip_resp = args.bind_ip
-                            else:
-                                tmp = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-                                try:
-                                    tmp.connect(addr)
-                                    contact_ip_resp = tmp.getsockname()[0]
-                                except OSError:
-                                    contact_ip_resp = sock.getsockname()[0]
-                                finally:
-                                    tmp.close()
+                            contact_ip_resp = sip_ip
                             resp = (
                                 "SIP/2.0 200 OK\r\n"
                                 f"Via: {via}\r\n"
@@ -1553,7 +1559,7 @@ def main():
                                 f"To: {to}\r\n"
                                 f"Call-ID: {call_id}\r\n"
                                 f"CSeq: {cseq_hdr}\r\n"
-                                f"Contact: <sip:{user}@{contact_ip_resp}:{sock.getsockname()[1]}>\r\n"
+                                f"Contact: <sip:{user}@{contact_ip_resp}:{local_port}>\r\n"
                                 "User-Agent: Dimitri-4000/0.1\r\n"
                                 "Allow: INVITE, ACK, CANCEL, OPTIONS, BYE\r\n"
                                 "Accept: application/sdp\r\n"
@@ -1861,7 +1867,7 @@ def main():
                                 "To": f"{dialog['to_uri']};tag={dialog['local_tag']}",
                                 "Call-ID": dialog["call_id"],
                                 "CSeq": dialog["cseq_hdr"],
-                                "Contact": f"<sip:{user}@{contact_ip}:{sock.getsockname()[1]}>",
+                                "Contact": f"<sip:{user}@{contact_ip}:{local_port}>",
                                 "Content-Type": "application/sdp",
                             }
                             offer_dir = dialog.get("offer_dir", "sendrecv") or "sendrecv"
@@ -1881,7 +1887,7 @@ def main():
                                 remote_effective,
                             )
                             sdp = build_sdp(
-                                contact_ip,
+                                sdp_ip,
                                 args.rtp_port,
                                 [
                                     (
@@ -1918,12 +1924,12 @@ def main():
                                     "To": f"{dialog['to_uri']};tag={dialog['local_tag']}",
                                     "Call-ID": dialog["call_id"],
                                     "CSeq": dialog["cseq_hdr"],
-                                    "Contact": f"<sip:{user}@{contact_ip}:{sock.getsockname()[1]}>",
+                                "Contact": f"<sip:{user}@{contact_ip}:{local_port}>",
                                     "Content-Type": "application/sdp",
                                 }
                                 answer_dir = dialog.get("answer_dir", args.sdp_direction)
                                 sdp = build_sdp(
-                                    contact_ip,
+                                    sdp_ip,
                                     args.rtp_port,
                                     [
                                         (

--- a/gui_tk.py
+++ b/gui_tk.py
@@ -40,6 +40,7 @@ from sip_manager import (
     strip_brackets,
 )
 from app import run_load_generator, sanitize_extra_headers
+from socket_handler import get_sip_transport
 
 # Configuration persisted in user home directory
 CONFIG_PATH = os.path.expanduser("~/.dimitri4000.json")
@@ -703,14 +704,11 @@ class App(tk.Tk):
             calls = self._int_or(self.entry_calls.get(), 1)
             dst_host = self.entry_dst_host.get().strip()
             dst_port = self._int_or(self.entry_dst_port.get(), 5060)
-            src_port_base = self._int_or(self.entry_src_port_base.get(), 5062)
-            src_port_step = self._int_or(self.entry_src_port_step.get(), 0)
             rtp_port_step = self._int_or(self.entry_rtp_port_step.get(), 2)
             return (
                 calls >= 1
                 and bool(dst_host)
                 and dst_port > 0
-                and src_port_base > 0
                 and rtp_port_step > 0
             )
         except Exception:
@@ -862,6 +860,7 @@ class App(tk.Tk):
 
         self.options_thread = OptionsMonitorThread(
             sock=sock,
+            sip_ip=getattr(self, "_shared_transport", None).bind_ip if getattr(self, "_shared_transport", None) else None,
             dst_host=dst_host,
             dst_port=dst_port,
             interval=interval,
@@ -1074,7 +1073,7 @@ class App(tk.Tk):
             self.log("UAC: no se pudo importar SIPManager")
             return
 
-        sm = SIPManager(sock=sock, logger=logging.getLogger("gui"))
+        sm = SIPManager(transport=self._shared_transport, logger=logging.getLogger("gui"))
         self._attach_dialog_callback(sm)
         self.sm = sm
         self._sm_for_gui = sm
@@ -1126,7 +1125,7 @@ class App(tk.Tk):
         if not cfg:
             return
         sock = self._ensure_shared_sock()
-        self.sm = SIPManager(sock=sock)
+        self.sm = SIPManager(transport=self._shared_transport)
         self._attach_dialog_callback(self.sm)
         t = threading.Thread(target=call_worker, args=(cfg, self.event_q, self.sm))
         t.daemon = True
@@ -1143,7 +1142,7 @@ class App(tk.Tk):
         if not cfg:
             return
         sock = self._ensure_shared_sock()
-        self.sm = SIPManager(sock=sock)
+        self.sm = SIPManager(transport=self._shared_transport)
         self._attach_dialog_callback(self.sm)
         self.stop_event.clear()
         t = threading.Thread(target=load_worker, args=(cfg, self.event_q, self.stop_event, self.sm))
@@ -1161,7 +1160,7 @@ class App(tk.Tk):
             if not cfg:
                 return
             sock = self._ensure_shared_sock()
-            sm = SIPManager(sock=sock)
+            sm = SIPManager(transport=self._shared_transport)
             self._attach_dialog_callback(sm)
             self.sm = sm
             self._sm_for_gui = sm
@@ -1222,10 +1221,9 @@ class App(tk.Tk):
             )
         except Exception:
             src_port = 0
-        s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-        s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-        s.bind((bind_ip, src_port))
-        s.settimeout(2.0)
+        transport = get_sip_transport(bind_ip, src_port)
+        self._shared_transport = transport
+        s = transport.sock
         self._shared_sock = s
         return s
 
@@ -1237,6 +1235,7 @@ class App(tk.Tk):
             except Exception:
                 pass
         self._shared_sock = None
+        self._shared_transport = None
 
     def on_bye_all_uac(self):
         sm = getattr(self, "_sm_for_gui", None)
@@ -1275,6 +1274,7 @@ class OptionsMonitorThread(threading.Thread):
         self,
         *,
         sock,
+        sip_ip: str | None,
         dst_host,
         dst_port,
         interval,
@@ -1297,6 +1297,7 @@ class OptionsMonitorThread(threading.Thread):
         self.last = None
         self.rx = 0
         self.local_ip = None
+        self.sip_ip = sip_ip
         self.extra_headers = list(extra_headers or [])
 
     def run(self):
@@ -1308,17 +1309,20 @@ class OptionsMonitorThread(threading.Thread):
             now = time.monotonic()
             if now >= next_send:
                 local_port = sock.getsockname()[1]
-                try:
-                    tmp = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-                    tmp.connect(self.dst)
-                    self.local_ip = tmp.getsockname()[0]
-                except Exception:
-                    self.local_ip = sock.getsockname()[0]
-                finally:
+                if self.sip_ip:
+                    self.local_ip = self.sip_ip
+                else:
                     try:
-                        tmp.close()
+                        tmp = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+                        tmp.connect(self.dst)
+                        self.local_ip = tmp.getsockname()[0]
                     except Exception:
-                        pass
+                        self.local_ip = sock.getsockname()[0]
+                    finally:
+                        try:
+                            tmp.close()
+                        except Exception:
+                            pass
                 call_id, payload = build_options(
                     self.dst[0],
                     self.local_ip,
@@ -1594,8 +1598,8 @@ def load_worker(cfg, event_q, stop_event, sm):
             from_user="dimitri",
             to_domain_load=cfg.get("to_domain") or cfg.get("dst_host"),
             from_domain_load=cfg.get("from_domain") or (cfg.get("bind_ip") or ""),
-            src_port_base=cfg.get("src_port_base", 0),
-            src_port_step=cfg.get("src_port_step", 10),
+            src_port_base=0,
+            src_port_step=0,
             rtp_port_base=cfg.get("rtp_port_base", 40000),
             rtp_port_step=cfg.get("rtp_port_step", 2),
             bind_ip=cfg.get("bind_ip") or None,
@@ -1631,7 +1635,6 @@ def load_worker(cfg, event_q, stop_event, sm):
             args.calls < 1
             or not args.dst
             or args.dst_port <= 0
-            or args.src_port_base <= 0
             or args.rtp_port_step <= 0
         ):
             event_q.put(("log", "Generador: parámetros inválidos; abortando"))
@@ -1647,7 +1650,7 @@ def load_worker(cfg, event_q, stop_event, sm):
             event_q.put(("uac", snapshot))
 
     try:
-        run_load_generator(args, sm, stats_cb=stats_cb)
+        run_load_generator(args, sm, sm.transport, stats_cb=stats_cb)
     except Exception as exc:  # noqa: BLE001
         event_q.put(("log", f"Generador: abortado ({exc})"))
         return
@@ -1669,6 +1672,7 @@ def uas_worker(cfg, event_q, stop_event, sm):
     if not codecs:
         codecs = [(0, "PCMU"), (8, "PCMA")]
     local_ip = sock.getsockname()[0]
+    sip_ip = (cfg.get("bind_ip") or local_ip).strip() if cfg.get("bind_ip") else local_ip
     rtp_port = int(cfg.get("rtp_port_base", "40000"))
     try:
         tone_hz = int(cfg.get("tone_hz", "0"))
@@ -1777,7 +1781,7 @@ def uas_worker(cfg, event_q, stop_event, sm):
                 headers200 = headers_base.copy()
                 headers200.update(
                     {
-                        "Contact": f"<sip:dimitri@{local_ip}:{sock.getsockname()[1]}>",
+                        "Contact": f"<sip:dimitri@{sip_ip}:{sock.getsockname()[1]}>",
                         "Allow": "INVITE, ACK, CANCEL, OPTIONS, BYE",
                         "Accept": "application/sdp",
                         "Content-Type": "application/sdp",

--- a/sip_manager.py
+++ b/sip_manager.py
@@ -11,6 +11,7 @@ import random
 import string
 from dataclasses import dataclass
 from typing import Dict, Tuple
+from socket_handler import SipTransport
 from rtp import RtpSession
 from sdp import (
     build_sdp,
@@ -547,13 +548,22 @@ class SIPManager:
         self,
         protocol: str = "udp",
         sock: socket.socket | None = None,
+        transport: SipTransport | None = None,
         bind_ip: str = "0.0.0.0",
         src_port: int = 0,
         logger: logging.Logger | None = None,
     ):
         self.protocol = protocol
         self.logger = logger or logging.getLogger("socket_handler")
-        if sock is None:
+        self.transport = transport
+        self.sip_bind_ip: str | None = None
+        self.sip_src_port: int | None = None
+        if transport is not None:
+            sock = transport.sock
+            self.sip_bind_ip = transport.bind_ip
+            self.sip_src_port = transport.src_port
+            self._own_sock = False
+        elif sock is None:
             sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
             if src_port:
                 sock.bind((bind_ip, src_port))
@@ -600,6 +610,11 @@ class SIPManager:
             except Exception:
                 pass
         return ip, port
+
+    def _sip_ip_port(self, fallback_ip: str, fallback_port: int) -> tuple[str, int]:
+        sip_ip = self.sip_bind_ip if self.sip_bind_ip not in (None, "") else fallback_ip
+        sip_port = self.sip_src_port if self.sip_src_port else fallback_port
+        return sip_ip, sip_port
 
     def _open_connected_udp(
         self,
@@ -727,7 +742,10 @@ class SIPManager:
             ctx["contact_user"],
         )
         try:
-            ctx["sock"].send(cancel)
+            if self.transport:
+                ctx["sock"].sendto(cancel, (ctx["dst_host"], ctx["dst_port"]))
+            else:
+                ctx["sock"].send(cancel)
         except OSError as e:
             if getattr(e, "errno", None) == errno.ECONNREFUSED:
                 logger.error(
@@ -788,19 +806,21 @@ class SIPManager:
 
         self._uac_lock.acquire()
         self._reset_call_state()
+        use_transport = self.transport is not None
         owned_socket = False
         prev_timeout = None
         if self.sock:
             s = self.sock
             prev_timeout = s.gettimeout()
-            try:
-                s.connect((dst_host, dst_port))
-            except OSError as e:
-                if getattr(e, "errno", None) == errno.ECONNREFUSED:
-                    logger.error(
-                        f"Destino no escucha en {dst_host}:{dst_port}"
-                    )
-                raise
+            if not use_transport:
+                try:
+                    s.connect((dst_host, dst_port))
+                except OSError as e:
+                    if getattr(e, "errno", None) == errno.ECONNREFUSED:
+                        logger.error(
+                            f"Destino no escucha en {dst_host}:{dst_port}"
+                        )
+                    raise
             local_ip, local_port = self._local_ip_port(s, dst_host, dst_port)
             s.settimeout(0.5)
         else:
@@ -810,6 +830,15 @@ class SIPManager:
             local_ip, local_port = self._local_ip_port(s, dst_host, dst_port)
             s.settimeout(0.5)
             owned_socket = True
+        sip_ip, sip_port = self._sip_ip_port(local_ip, local_port)
+        current_dst = (dst_host, dst_port)
+
+        def send_data(payload: bytes, dst: tuple[str, int] | None = None) -> None:
+            target = dst or current_dst
+            if use_transport:
+                s.sendto(payload, target)
+            else:
+                s.send(payload)
 
         if from_uri:
             if not from_uri.startswith("sip:"):
@@ -892,8 +921,8 @@ class SIPManager:
             request_uri,
             from_uri,
             to_uri,
-            local_ip,
-            local_port,
+            sip_ip,
+            sip_port,
             call_id,
             invite_cseq,
             tag,
@@ -911,8 +940,8 @@ class SIPManager:
             "sock": s,
             "request_uri": request_uri,
             "to_uri": to_uri,
-            "local_ip": local_ip,
-            "local_port": local_port,
+            "local_ip": sip_ip,
+            "local_port": sip_port,
             "from_uri": from_uri,
             "from_display": from_display,
             "call_id": call_id,
@@ -928,10 +957,10 @@ class SIPManager:
         self.cancel_requested = False
 
         logger.info(
-            f"Enviando INVITE (CSeq={invite_cseq}) a {dst_host}:{dst_port} sent-by={local_ip}:{local_port}"
+            f"Enviando INVITE (CSeq={invite_cseq}) a {dst_host}:{dst_port} sent-by={sip_ip}:{sip_port}"
         )
         try:
-            s.send(invite)
+            send_data(invite)
         except OSError as e:
             if getattr(e, "errno", None) == errno.ECONNREFUSED:
                 logger.error(
@@ -954,7 +983,7 @@ class SIPManager:
         got_provisional = False
         
         def send_bye(cseq: int) -> int:
-            nonlocal to_header, remote_target
+            nonlocal to_header, remote_target, current_dst
             auth_hdr = None
             if auth_user and auth_pass and auth_state.get("nonce"):
                 cnonce = secrets.token_hex(8)
@@ -982,15 +1011,18 @@ class SIPManager:
                 try:
                     _, h, p = _contact_uri_host_port(send_uri)
                     if p is None:
-                        p = s.getpeername()[1]
-                    s.connect((h, p))
+                        p = current_dst[1]
+                    if use_transport:
+                        current_dst = (h, p)
+                    else:
+                        s.connect((h, p))
                 except Exception:
                     pass
             bye = build_uac_bye_request(
                 remote_target,
                 to_header,
-                local_ip,
-                local_port,
+                sip_ip,
+                sip_port,
                 from_uri,
                 from_display,
                 call_id,
@@ -1000,10 +1032,13 @@ class SIPManager:
                 auth_header=auth_hdr,
                 route_set=route_set,
             )
-            s.send(bye)
+            send_data(bye, current_dst)
             while True:
                 try:
-                    data2 = s.recv(4096)
+                    if use_transport:
+                        data2, _ = s.recvfrom(4096)
+                    else:
+                        data2 = s.recv(4096)
                 except socket.timeout:
                     return cseq
                 except OSError as e:
@@ -1014,6 +1049,8 @@ class SIPManager:
                         return cseq
                     raise
                 start2, headers2 = parse_headers(data2)
+                if use_transport and headers2.get("call-id") != call_id:
+                    continue
                 c2, _ = status_from_response(data2)
                 if c2 in (401, 407) and auth_user and auth_pass and not auth_state.get("bye_auth_done"):
                     chall = headers2.get("www-authenticate" if c2 == 401 else "proxy-authenticate")
@@ -1029,8 +1066,8 @@ class SIPManager:
                         ack = build_ack(
                             remote_target,
                             to_hdr,
-                            local_ip,
-                            local_port,
+                            sip_ip,
+                            sip_port,
                             from_uri,
                             from_display,
                             call_id,
@@ -1038,7 +1075,7 @@ class SIPManager:
                             tag,
                             contact_user,
                         )
-                        s.send(ack)
+                        send_data(ack, current_dst)
                         cseq += 1
                         cnonce = secrets.token_hex(8)
                         auth_state["nc"] = auth_state.get("nc", 0) + 1
@@ -1058,8 +1095,8 @@ class SIPManager:
                         bye = build_uac_bye_request(
                             remote_target,
                             to_hdr,
-                            local_ip,
-                            local_port,
+                            sip_ip,
+                            sip_port,
                             from_uri,
                             from_display,
                             call_id,
@@ -1069,7 +1106,7 @@ class SIPManager:
                             auth_header=(hdr_name, auth_val),
                             route_set=route_set,
                         )
-                        s.send(bye)
+                        send_data(bye, current_dst)
                         auth_state["bye_auth_done"] = True
                         continue
                 if c2 == 200:
@@ -1111,7 +1148,10 @@ class SIPManager:
                     break
 
                 try:
-                    data = s.recv(4096)
+                    if use_transport:
+                        data, _ = s.recvfrom(4096)
+                    else:
+                        data = s.recv(4096)
                 except socket.timeout:
                     now = time.monotonic()
                     if (
@@ -1121,7 +1161,7 @@ class SIPManager:
                         and retries < MAX_RETX
                     ):
                         try:
-                            s.send(invite)
+                            send_data(invite)
                         except OSError as e:
                             if getattr(e, "errno", None) == errno.ECONNREFUSED:
                                 logger.error(
@@ -1148,6 +1188,8 @@ class SIPManager:
 
                 code, reason = status_from_response(data)
                 start, headers = parse_headers(data)
+                if use_transport and headers.get("call-id") != call_id:
+                    continue
                 cseq_hdr = headers.get("cseq", "")
                 if code is not None and 100 <= code < 200:
                     got_provisional = True
@@ -1163,8 +1205,8 @@ class SIPManager:
                         ack = build_ack(
                             request_uri,
                             to_header,
-                            local_ip,
-                            local_port,
+                            sip_ip,
+                            sip_port,
                             from_uri,
                             from_display,
                             call_id,
@@ -1172,7 +1214,7 @@ class SIPManager:
                             tag,
                             contact_user,
                         )
-                        s.send(ack)
+                        send_data(ack)
                         self._clear_ring_timer()
                         self.failed = True
                         setup_ms = int((time.monotonic() - t_start) * 1000)
@@ -1198,8 +1240,8 @@ class SIPManager:
                         ack = build_ack(
                             request_uri,
                             to_header,
-                            local_ip,
-                            local_port,
+                            sip_ip,
+                            sip_port,
                             from_uri,
                             from_display,
                             call_id,
@@ -1207,7 +1249,7 @@ class SIPManager:
                             tag,
                             contact_user,
                         )
-                        s.send(ack)
+                        send_data(ack)
                         invite_cseq += 1
                         cnonce = secrets.token_hex(8)
                         auth_state["nc"] = auth_state.get("nc", 0) + 1
@@ -1229,8 +1271,8 @@ class SIPManager:
                             request_uri,
                             from_uri,
                             to_uri,
-                            local_ip,
-                            local_port,
+                            sip_ip,
+                            sip_port,
                             call_id,
                             invite_cseq,
                             tag,
@@ -1254,7 +1296,7 @@ class SIPManager:
                         )
                         logger.info("Reenviando INVITE con autenticacion Digest")
                         try:
-                            s.send(invite)
+                            send_data(invite)
                         except OSError as e:
                             if getattr(e, "errno", None) == errno.ECONNREFUSED:
                                 logger.error(
@@ -1318,10 +1360,7 @@ class SIPManager:
                     if contact:
                         remote_target, host, port = _contact_uri_host_port(contact)
                         if port is None:
-                            try:
-                                port = s.getpeername()[1]
-                            except OSError:
-                                port = 5060
+                            port = current_dst[1] if current_dst else 5060
                             if "@" in remote_target:
                                 user_part, host_part = remote_target.split("@", 1)
                                 if ";" in host_part:
@@ -1332,18 +1371,21 @@ class SIPManager:
                             elif remote_target.startswith("sip:"):
                                 host_only = remote_target[4:]
                                 remote_target = f"sip:{host_only}:{port}"
-                        try:
-                            s.connect((host, port))
-                        except OSError:
-                            pass
+                        if use_transport:
+                            current_dst = (host, port)
+                        else:
+                            try:
+                                s.connect((host, port))
+                            except OSError:
+                                pass
                     rr = headers.get("record-route")
                     if rr:
                         route_set = _route_set_from_record_route(rr)
                     ack = build_ack(
                         remote_target,
                         to_header,
-                        local_ip,
-                        local_port,
+                        sip_ip,
+                        sip_port,
                         from_uri,
                         from_display,
                         call_id,
@@ -1356,7 +1398,7 @@ class SIPManager:
                     ctx = self._current_call or {}
                     ctx["remote_target"] = remote_target
                     ctx["to_header"] = to_header
-                    s.send(ack)
+                    send_data(ack, current_dst)
                     if negotiated_pt is None:
                         logger.warning(
                             "unsupported negotiated codec pts=%s local=%s",
@@ -1407,12 +1449,12 @@ class SIPManager:
                         remote_tag=remote_tag,
                         route_set=route_set.copy(),
                         remote_target=remote_target,
-                        local_contact=f"sip:{contact_user}@{local_ip}:{local_port}",
+                        local_contact=f"sip:{contact_user}@{sip_ip}:{sip_port}",
                         cseq_local=invite_cseq,
                         cseq_remote=remote_cseq,
                         sock=s,
-                        local_ip=local_ip,
-                        local_port=local_port,
+                        local_ip=sip_ip,
+                        local_port=sip_port,
                         role="uac",
                         dst=(dst_host, dst_port),
                         rtp=rtp,
@@ -1430,7 +1472,11 @@ class SIPManager:
                                     result = "max-time-bye"
                                     break
                                 try:
-                                    data2 = s.recv(4096)
+                                    if use_transport:
+                                        data2, addr2 = s.recvfrom(4096)
+                                    else:
+                                        data2 = s.recv(4096)
+                                        addr2 = None
                                 except socket.timeout:
                                     continue
                                 except OSError as e:
@@ -1441,14 +1487,16 @@ class SIPManager:
                                         raise
                                     raise
                                 start2, headers2 = parse_headers(data2)
-                                if self.handle_uac_bye(data2, sock=s):
+                                if use_transport and headers2.get("call-id") != call_id:
+                                    continue
+                                if self.handle_uac_bye(data2, addr=addr2, sock=s):
                                     result = "remote-bye"
                                     break
                                 c2, _ = status_from_response(data2)
                                 if c2 == 200:
                                     dialog = self.uac_dialogs.get(call_id)
                                     if dialog and dialog.state != "terminated":
-                                        s.send(ack)
+                                        send_data(ack, current_dst)
                                     continue
                                 if start2.startswith("INVITE") or start2.startswith(
                                     "UPDATE"
@@ -1469,8 +1517,8 @@ class SIPManager:
                     ack = build_ack(
                         request_uri,
                         to_header,
-                        local_ip,
-                        local_port,
+                        sip_ip,
+                        sip_port,
                         from_uri,
                         from_display,
                         call_id,
@@ -1478,7 +1526,7 @@ class SIPManager:
                         tag,
                         contact_user,
                     )
-                    s.send(ack)
+                    send_data(ack)
                     setup_ms = int((time.monotonic() - t_start) * 1000)
                     result = "canceled"
                     break
@@ -1488,8 +1536,8 @@ class SIPManager:
                     ack = build_ack(
                         request_uri,
                         to_header,
-                        local_ip,
-                        local_port,
+                        sip_ip,
+                        sip_port,
                         from_uri,
                         from_display,
                         call_id,
@@ -1497,7 +1545,7 @@ class SIPManager:
                         tag,
                         contact_user,
                     )
-                    s.send(ack)
+                    send_data(ack)
                     self._clear_ring_timer()
                     self.failed = True
                     setup_ms = int((time.monotonic() - t_start) * 1000)
@@ -1525,7 +1573,8 @@ class SIPManager:
                     try:
                         if prev_timeout is not None:
                             s.settimeout(prev_timeout)
-                        s.connect(("0.0.0.0", 0))
+                        if not use_transport:
+                            s.connect(("0.0.0.0", 0))
                     except OSError:
                         pass
                 if 'rtp' in locals():
@@ -1695,8 +1744,11 @@ class SIPManager:
                         dst = dlg.dst
                         if not dst:
                             continue
-                        src_ip, src_port = self._local_ip_port(
+                        fallback_ip, fallback_port = self._local_ip_port(
                             self.sock, dst[0], dst[1]
+                        )
+                        src_ip, src_port = self._sip_ip_port(
+                            fallback_ip, fallback_port
                         )
                         bye_text = build_bye_request(
                             dlg, src_ip, src_port, transport=self.protocol.upper()
@@ -1711,8 +1763,11 @@ class SIPManager:
                         )
                         self.sock.sendto(bye_text.encode(), dst)
                     else:
-                        src_ip, src_port = self._local_ip_port(
+                        fallback_ip, fallback_port = self._local_ip_port(
                             self.sock, dlg["dst"][0], dlg["dst"][1]
+                        )
+                        src_ip, src_port = self._sip_ip_port(
+                            fallback_ip, fallback_port
                         )
                         bye = build_bye(dlg)
                         self.logger.info(
@@ -1736,10 +1791,15 @@ class SIPManager:
         for key, dlg in list(dialogs.items()):
             dst = getattr(dlg, "dst", None)
             try:
-                if dst and dlg.sock:
-                    src_ip, src_port = self._local_ip_port(dlg.sock, dst[0], dst[1])
-                else:
-                    src_ip, src_port = dlg.local_ip, dlg.local_port
+            if dst and dlg.sock:
+                fallback_ip, fallback_port = self._local_ip_port(
+                    dlg.sock, dst[0], dst[1]
+                )
+                src_ip, src_port = self._sip_ip_port(
+                    fallback_ip, fallback_port
+                )
+            else:
+                src_ip, src_port = dlg.local_ip, dlg.local_port
                 bye_text = build_bye_request(
                     dlg, src_ip, src_port, transport=self.protocol.upper()
                 )

--- a/socket_handler.py
+++ b/socket_handler.py
@@ -12,6 +12,47 @@ setup_logging()
 logger = logging.getLogger(__name__)
 
 
+class SipTransport:
+    def __init__(self, bind_ip: str, src_port: int):
+        self.bind_ip = bind_ip
+        self.src_port = int(src_port)
+        self.sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        self.sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        try:
+            self.sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEPORT, 1)
+        except Exception:
+            pass
+        self.sock.bind((bind_ip, self.src_port))
+        self.sock.settimeout(0.5)
+
+    def sendto(self, data: bytes, dst_addr):
+        return self.sock.sendto(data, dst_addr)
+
+    def recvfrom(self, bufsize: int = 65535):
+        return self.sock.recvfrom(bufsize)
+
+    def close(self) -> None:
+        try:
+            self.sock.close()
+        except Exception:
+            pass
+
+
+_SIP_TRANSPORT: SipTransport | None = None
+
+
+def get_sip_transport(bind_ip: str, src_port: int) -> SipTransport:
+    """Return a singleton SipTransport for the provided bind_ip/src_port."""
+    global _SIP_TRANSPORT
+    if _SIP_TRANSPORT is None:
+        _SIP_TRANSPORT = SipTransport(bind_ip, src_port)
+    else:
+        if _SIP_TRANSPORT.bind_ip != bind_ip or _SIP_TRANSPORT.src_port != int(src_port):
+            _SIP_TRANSPORT.close()
+            _SIP_TRANSPORT = SipTransport(bind_ip, src_port)
+    return _SIP_TRANSPORT
+
+
 def _validate_ip(ip: str) -> None:
     """Raise ValueError if *ip* is not a valid IPv4 or IPv6 address."""
     try:

--- a/tui.py
+++ b/tui.py
@@ -7,6 +7,7 @@ from types import SimpleNamespace
 
 from sip_manager import SIPManager
 from app import run_load_generator
+from socket_handler import get_sip_transport
 
 # Default configuration values for editable fields
 DEFAULT_CONFIG = {
@@ -248,7 +249,8 @@ def controller(cmd_q, event_q, stop_event):
 
 def options_worker(cfg, event_q):
     counters = {"sent": 0, "ok": 0, "other": 0, "timeout": 0}
-    sm = SIPManager(protocol="udp")
+    sip_transport = get_sip_transport(cfg.get("bind_ip") or "0.0.0.0", int(cfg.get("src_port", "0") or 0))
+    sm = SIPManager(protocol="udp", transport=sip_transport)
     dst = cfg.get("dst_host")
     dport = int(cfg.get("dst_port", 5060))
     for _ in range(3):
@@ -331,8 +333,8 @@ def load_worker(cfg, event_q, stop_event):
         from_user="dimitri",
         to_domain_load=cfg.get("to_domain") or cfg.get("dst_host"),
         from_domain_load=cfg.get("from_domain") or (cfg.get("bind_ip") or ""),
-        src_port_base=int(cfg.get("src_port", "0")),
-        src_port_step=10,
+        src_port_base=0,
+        src_port_step=0,
         rtp_port_base=int(cfg.get("rtp_port_base", "40000")),
         rtp_port_step=2,
         bind_ip=cfg.get("bind_ip") or None,
@@ -351,12 +353,13 @@ def load_worker(cfg, event_q, stop_event):
         rate=float(cfg.get("rate", "1.0")),
         max_active=int(cfg.get("max_active", "1")),
     )
-    sm = SIPManager(protocol="udp")
+    sip_transport = get_sip_transport(cfg.get("bind_ip") or "0.0.0.0", int(cfg.get("src_port", "0") or 0))
+    sm = SIPManager(protocol="udp", transport=sip_transport)
 
     def stats_cb(snapshot):
         event_q.put(("uac", snapshot))
 
-    run_load_generator(args, sm, stats_cb=stats_cb)
+    run_load_generator(args, sm, sip_transport, stats_cb=stats_cb)
     event_q.put(("log", "Load finished"))
 
 
@@ -367,4 +370,3 @@ def uas_worker(cfg, event_q, stop_event):
             time.sleep(0.5)
     finally:
         event_q.put(("log", "UAS service stopped"))
-


### PR DESCRIPTION
### Motivation

- Use a single UDP socket (bind_ip + src_port) for all SIP traffic so the app no longer opens a socket per call.
- In generator mode, keep the SIP source port constant and only step RTP local ports according to `rtp_port_step`.
- Start RTP only after the UAC has sent the ACK for a 200 OK and the remote SDP is parsed.
- Ensure remote BYE is always answered with 200 OK and that RTP for that dialog is stopped and cleaned up.

### Description

- Added a `SipTransport` singleton in `socket_handler.py` and `get_sip_transport()` to create/return the shared SIP socket.
- Wired the shared transport into call paths: `SIPManager` now accepts a `transport` and derives the sent-by (`bind_ip:src_port`) used in `Via`/`Contact` headers, and `app.py`/`gui_tk.py`/`tui.py` use `get_sip_transport()` instead of opening per-call sockets.
- Load generator rewrite: `run_load_generator()` now receives the shared `sip_transport`, dispatches incoming SIP datagrams to per-call queues, and no longer steps SIP source ports (removed `src_port_base/src_port_step` usage for SIP); only RTP ports step with `rtp_port_step` and RTP is started after ACK parsing of 200 OK SDP.
- `SIPManager` send/recv logic updated to use the transport when present (send via `sendto` and recv via `recvfrom`), keep local RTP handling, reply 200 OK to remote BYE and stop RTP, and use transport bind address/port for headers and dialog local_contact.

### Testing

- No automated tests were executed as part of this change (none requested in the rollout).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695ba520088c8329944623d359bd6c68)